### PR TITLE
[DEV 2.0] Disable speech recognition in WebSocket service

### DIFF
--- a/app/services/websocket.py
+++ b/app/services/websocket.py
@@ -23,8 +23,9 @@ async def websocket_endpoint(websocket: WebSocket):
     
     try:
         while True:
+            user_input = await websocket.receive_text() # user input now points to incoming transcription from WebSocket client
             # Run the speech recognition in a separate thread, so it doesn't block.
-            user_input = await asyncio.to_thread(recognize_speech)
+            # user_input = await asyncio.to_thread(recognize_speech)
             if user_input:
                 print(f"User said: {user_input}")
 


### PR DESCRIPTION
The speech recognition is now being handled in the client-side frontend: https://github.com/SpeakWrite-CSC301/speakwrite-ui/pull/13. Note that I haven't omitted the speech recognition logic from here, in case any code segments are needed in the future. The `recognize_speech()` function is simply just being unused now.