### PR TITLE
[DEV 2.15] Add a PATCH endpoint for renaming sessions

### DIFF
--- a/app/routers/session.py
+++ b/app/routers/session.py
@@ -17,3 +17,10 @@ def create_session(session: Session):
     if response.status_code != 200:
         return {"error": "DB SERVICE ERROR: Failed to create session."}
     return response.json()
+
+@router.patch("/sessions/{session_id}", tags=["sessions"])
+def update_session_name(session_id: int, new_session_data: dict):
+    response = requests.patch(f"{DB_SERVICE_URL}/sessions/{session_id}", json=new_session_data)
+    if response.status_code != 200:
+        return {"error": "DB SERVICE ERROR: Failed to update session."}
+    return response.json()


### PR DESCRIPTION
It takes in a path argument (`session_id`) as a means to filter out the session to rename.

Here is a sample request, after checking out the branch (from both this PR and the PR in speakwrite-db) and running your API and DB services:

```
curl -X PATCH "http://localhost:8001/sessions/86" \
     -H "Content-Type: application/json" \
     -d '{"new_session_name": "NEW NAME"}'
```

and you will see the new name reflected on that session on your `localhost:8001/sessions` response.

Related to: #10 