### PR TITLE
[DEV 2.15] Populating content on sessions

### DIFF
--- a/app/routers/chat.py
+++ b/app/routers/chat.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter;
 from schemas import Chat, DB_SERVICE_URL
+from .session import update_session
 import requests
 
 router = APIRouter()
@@ -16,4 +17,5 @@ def create_chat(chat: Chat):
     response = requests.post(f"{DB_SERVICE_URL}/chats", json=chat.model_dump())
     if response.status_code != 200:
         return {"error": "DB SERVICE ERROR: Failed to create chat"}
+    update_session(chat.session_id, {"message": chat.message})
     return response.json()

--- a/app/routers/session.py
+++ b/app/routers/session.py
@@ -11,6 +11,13 @@ def read_sessions():
         return {"error": "DB SERVICE ERROR: Failed to fetch sessions"}
     return response.json()
 
+@router.get("/sessions/{session_id}", tags=["sessions"])
+def read_session(session_id: int): # Gets session matching the given session_id
+    response = requests.get(f"{DB_SERVICE_URL}/sessions/{session_id}")
+    if response.status_code != 200:
+        return {"error": "DB SERVICE ERROR: Failed to fetch requested session."}
+    return response.json()
+
 @router.post("/sessions", tags=["sessions"])
 def create_session(session: Session):
     response = requests.post(f"{DB_SERVICE_URL}/sessions", json=session.model_dump())
@@ -19,7 +26,7 @@ def create_session(session: Session):
     return response.json()
 
 @router.patch("/sessions/{session_id}", tags=["sessions"])
-def update_session_name(session_id: int, new_session_data: dict):
+def update_session(session_id: int, new_session_data: dict):
     response = requests.patch(f"{DB_SERVICE_URL}/sessions/{session_id}", json=new_session_data)
     if response.status_code != 200:
         return {"error": "DB SERVICE ERROR: Failed to update session."}


### PR DESCRIPTION
The chat POST handler now calls the function corresponding to the session PATCH endpoints. This attains population of content onto specific session objects, based on the `session_id` that is also visible in the Chat model.

A new endpoint for GETting specific sessions has been added to retrieve sessions matching the `session_id` path argument. This will be useful in file navigation.

Fixes #14 